### PR TITLE
Updating 'agent.exe' refs to 'amazon-ecs-agent.exe'

### DIFF
--- a/agent/functional_tests/README.md
+++ b/agent/functional_tests/README.md
@@ -59,18 +59,18 @@ done first:
   `iptables -t nat -A OUTPUT -d 169.254.170.2 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 51679`
   and `export TEST_TASK_IAM_ROLE_NET_HOST=true`
 
-### Windows
+### Custom Agent
 
-Before running these tests, you should build the ECS agent (as `agent.exe`) and
-record the directory where the binary is present in the `ECS_WINDOWS_TEST_DIR`
-environment variable.
+If you want to change the tests to point to a custom agent exe:
+Before running these tests, record the directory where the binary is present
+in the `ECS_WINDOWS_TEST_DIR` environment variable.
 
 #### Environment variables
 You can configure the following environment variables to change test
 execution behavior:
 * `AWS_REGION`: Control the region that is used for test execution
 * `ECS_CLUSTER`: Control the cluster used for test execution
-* `ECS_WINDOWS_TEST_DIR`: Override the path used to find `agent.exe`
+* `ECS_WINDOWS_TEST_DIR`: Override the path used to find `amazon-ecs-agent.exe`
 * `ECS_FTEST_TMP`: Override the default temporary directory used for storing
   test logs and data files
 

--- a/agent/functional_tests/README.md
+++ b/agent/functional_tests/README.md
@@ -59,11 +59,11 @@ done first:
   `iptables -t nat -A OUTPUT -d 169.254.170.2 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 51679`
   and `export TEST_TASK_IAM_ROLE_NET_HOST=true`
 
-### Custom Agent
+### Windows
 
-If you want to change the tests to point to a custom agent exe:
-Before running these tests, record the directory where the binary is present
-in the `ECS_WINDOWS_TEST_DIR` environment variable.
+Before running these tests, you should build the ECS agent (as `amazon-ecs-agent.exe`) and
+record the directory where the binary is present in the `ECS_WINDOWS_TEST_DIR`
+environment variable.
 
 #### Environment variables
 You can configure the following environment variables to change test

--- a/agent/functional_tests/util/utils_windows.go
+++ b/agent/functional_tests/util/utils_windows.go
@@ -120,7 +120,7 @@ func (agent *TestAgent) StartAgent() error {
 			os.Setenv(k, v)
 		}
 	}
-	agentInvoke := exec.Command(".\\agent.exe")
+	agentInvoke := exec.Command(".\\amazon-ecs-agent.exe")
 	if TestDirectory := os.Getenv("ECS_WINDOWS_TEST_DIR"); TestDirectory != "" {
 		agentInvoke.Dir = TestDirectory
 	}

--- a/misc/windows-deploy/amazon-ecs-agent.ps1
+++ b/misc/windows-deploy/amazon-ecs-agent.ps1
@@ -70,7 +70,7 @@ try {
     try {
         .\amazon-ecs-agent.exe
     } catch {
-        LogMsg -message "Could not start agent.exe." -logLevel "ERROR"
+        LogMsg -message "Could not start amazon-ecs-agent.exe." -logLevel "ERROR"
         LogMsg -message $_.Exception.Message -logLevel "ERROR"
         exit 2
     }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/aws/amazon-ecs-agent/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

### Summary
<!-- What does this pull request do? -->
Update all 'agent.exe' refs to 'amazon-ecs-agent.exe'

### Implementation details
<!-- How are the changes implemented? -->
Find replace

### Testing
<!-- How was this tested? -->
Testing in progress...
<!--
Note for external contributors:
`make test` and `make run-integ-tests` can run in a Linux development
environment like your laptop.  `go test -timeout=25s ./agent/...` and
`.\scripts\run-integ.tests.ps1` can run in a Windows development environment
like your laptop.  Please ensure unit and integration tests pass (on at least
one platform) before opening the pull request.  `make run-functional-tests` and
`.\scripts\run-functional-tests.ps1` must be run on an EC2 instance with an
instance profile allowing it access to AWS resources.  Running
`make run-functional-tests` and `.\scripts\run-functional-tests.ps1` may incur
charges to your AWS account; if you're unable or unwilling to run these tests
in your own account, we can run the tests and provide test results.
-->
- [x] Builds on Linux (`make release`)
- [x] Builds on Windows (`go build -out amazon-ecs-agent.exe ./agent`)
- [x] Unit tests on Linux (`make test`) pass
- [x] Unit tests on Windows (`go test -timeout=25s ./agent/...`) pass
- [x] Integration tests on Linux (`make run-integ-tests`) pass
- [x] Integration tests on Windows (`.\scripts\run-integ-tests.ps1`) pass
- [x] Functional tests on Linux (`make run-functional-tests`) pass
- [x] Functional tests on Windows (`.\scripts\run-functional-tests.ps1`) pass

New tests cover the changes: no

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
You can see our changelog entry style here:
https://github.com/aws/amazon-ecs-agent/commit/c9aefebc2b3007f09468f651f6308136bd7b384f
-->
Update all 'agent.exe' refs to 'amazon-ecs-agent.exe'

### Licensing
<!--
Please confirm that this contribution is under the terms of the Apache 2.0
License.
-->
This contribution is under the terms of the Apache 2.0 License: yes
